### PR TITLE
Fix YAML syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ service: my-serverless-project
 provider:
   # ...
 plugins:
-  serverless-sentry
+  - serverless-sentry
 custom:
   sentry:
     dsn: https://xxxx:yyyy@sentry.io/zzzz # URL provided by Sentry
@@ -296,7 +296,7 @@ service: my-serverless-project
 provider:
   # ...
 plugins:
-  serverless-sentry
+  - serverless-sentry
 custom:
   sentry:
     dsn: https://xxxx:yyyy@sentry.io/zzzz # URL provided by Sentry
@@ -329,7 +329,7 @@ Also make sure to add the plugin to your plugins list in the `serverless.yml`:
 
 ```yaml
 plugins:
-  serverless-sentry
+  - serverless-sentry
 custom:
   sentry:
     dsn: https://xxxx:yyyy@sentry.io/zzzz # URL provided by Sentry
@@ -342,7 +342,7 @@ the example below:
 
 ```yaml
 plugins:
-  serverless-sentry
+  - serverless-sentry
 custom:
   sentry:
     dsn: https://xxxx:yyyy@sentry.io/zzzz # URL provided by Sentry


### PR DESCRIPTION
The example configuration will not propagate the Sentry DSN (and other configuration) to environment variables with the current version of Serverless.

    plugins:
      serverless-sentry

parses as `{"plugins": "serverless-sentry"}`, instead of `{"plugins": ["serverless-sentry"]}` - we mean the latter, so we need a hyphen here. Perhaps Serverless used to allow a single string to work as the value for the `plugins` key, but it does not in the current version (1.26.1).