### PR TITLE
Support function only deploy as well

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,17 @@ export class SentryPlugin implements Plugin {
         await this.deploySentryRelease();
       },
 
+       "before:deploy:function:deploy": async () => {
+        await this.validate();
+        await this.setRelease();
+        await this.instrumentFunctions();
+      },
+
+      "after:deploy:function:deploy": async () => {
+        await this.createSentryRelease();
+        await this.deploySentryRelease();
+      },
+      
       "before:invoke:local:invoke": async () => {
         await this.validate();
         await this.setRelease();


### PR DESCRIPTION
After my first deploy of the stack I usally deploy the function only with the -f parameter to speed up deployment. This should also be catched and a release should be added to Sentry.