### PR TITLE
Add enable config

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Configure the Sentry plugin using the following options in your
 `serverless.yml`:
 
 - `dsn` - Your Sentry project's DSN url (required)
+- `enabled` - Specifies whether this SDK should activate and send events to Sentry (defaults to `true`)
 - `environment` - Explicitly set the Sentry environment (defaults to the
   Serverless stage)
 
@@ -262,6 +263,7 @@ plugins:
 custom:
   sentry:
     dsn: https://xxxx:yyyy@sentry.io/zzzz # URL provided by Sentry
+    enabled: ${self:provider.stage, 'dev'} == prod # only will enable if stage is prod, if the stage is not defined will be considered as dev
     captureTimeoutWarnings: false # disable timeout warnings globally for all functions
 functions:
   FuncFoo:

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -18,6 +18,8 @@ export declare type SentryOptions = {
     organization?: string;
     project?: string;
     release?: SentryRelease | string | boolean;
+    /** Specifies whether this SDK should activate and send events to Sentry. (defaults to `true`) */
+    enabled?: boolean;
     /** Don't report errors from local environments (defaults to `true`) */
     filterLocal?: boolean;
     /** Enable source maps (defaults to `false`) */

--- a/dist/index.js
+++ b/dist/index.js
@@ -226,6 +226,10 @@ var SentryPlugin = /** @class */ (function () {
             newDefinition.environment.SENTRY_SOURCEMAPS = String(sentryConfig.sourceMaps);
             setEnv && (process.env.SENTRY_SOURCEMAPS = newDefinition.environment.SENTRY_SOURCEMAPS);
         }
+        if (typeof sentryConfig.enabled !== "undefined") {
+            newDefinition.environment.SENTRY_ENABLED = String(sentryConfig.enabled);
+            setEnv && (process.env.SENTRY_ENABLED = newDefinition.environment.SENTRY_ENABLED);
+        }
         if (typeof sentryConfig.filterLocal !== "undefined") {
             newDefinition.environment.SENTRY_FILTER_LOCAL = String(sentryConfig.filterLocal);
             setEnv && (process.env.SENTRY_FILTER_LOCAL = newDefinition.environment.SENTRY_FILTER_LOCAL);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ export type SentryOptions = {
   project?: string;
   release?: SentryRelease | string | boolean;
 
+  /** Specifies whether this SDK should activate and send events to Sentry (defaults to `true`) */
+  enabled?: boolean;
   /** Don't report errors from local environments (defaults to `true`) */
   filterLocal?: boolean;
   /** Enable source maps (defaults to `false`) */
@@ -178,6 +180,10 @@ export class SentryPlugin implements Plugin {
     if (typeof sentryConfig.sourceMaps !== "undefined") {
       newDefinition.environment.SENTRY_SOURCEMAPS = String(sentryConfig.sourceMaps);
       setEnv && (process.env.SENTRY_SOURCEMAPS = newDefinition.environment.SENTRY_SOURCEMAPS);
+    }
+    if (typeof sentryConfig.enabled !== "undefined") {
+      newDefinition.environment.SENTRY_ENABLED = String(sentryConfig.enabled);
+      setEnv && (process.env.SENTRY_ENABLED = newDefinition.environment.SENTRY_ENABLED);
     }
     if (typeof sentryConfig.filterLocal !== "undefined") {
       newDefinition.environment.SENTRY_FILTER_LOCAL = String(sentryConfig.filterLocal);


### PR DESCRIPTION
Specifies whether this SDK should activate and send events to Sentry.
Disabling the SDK reduces all overhead from instrumentation, collecting breadcrumbs and capturing events.

Defaults to true.

closes #46