### PR TITLE
replace String with JSON.stringify

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -261,7 +261,7 @@ export class SentryPlugin implements Plugin {
       setEnv && (process.env.SENTRY_AUTO_BREADCRUMBS = newDefinition.environment.SENTRY_AUTO_BREADCRUMBS);
     }
     if (typeof sentryConfig.sourceMaps !== "undefined") {
-      newDefinition.environment.SENTRY_SOURCEMAPS = String(sentryConfig.sourceMaps);
+      newDefinition.environment.SENTRY_SOURCEMAPS = JSON.stringify(sentryConfig.sourceMaps);
       setEnv && (process.env.SENTRY_SOURCEMAPS = newDefinition.environment.SENTRY_SOURCEMAPS);
     }
     if (typeof sentryConfig.filterLocal !== "undefined") {


### PR DESCRIPTION
This is clearly a bug, because when I have value of sourceMaps in my config like
```
sourceMaps:
  urlPrefix: /var/task
```
It's serialized like `[object Object]` and that's what I see on environment variable in lambda configuration. I am not sure what this variables is needed for (is it needed at all?), but definitely it shouldn't look like that.

Could it be that for other cases here we should replace `String(...)` with `JSON.stringify(...)`?

![image](https://user-images.githubusercontent.com/1200256/176440256-171cb984-2b26-4793-86c9-843f953a8048.png)
