### PR TITLE
disable uploading source maps for deploying single function

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -60,6 +60,7 @@ export declare class SentryPlugin implements Plugin {
     sentry: Partial<SentryOptions>;
     serverless: Serverless;
     options: Serverless.Options;
+    logging: Plugin.Logging;
     custom: Service.Custom;
     hooks: {
         [event: string]: (...rest: any[]) => any;
@@ -67,7 +68,7 @@ export declare class SentryPlugin implements Plugin {
     provider: Aws;
     validated: boolean;
     isInstrumented: boolean;
-    constructor(serverless: Serverless, options: Serverless.Options);
+    constructor(serverless: Serverless, options: Serverless.Options, logging: Plugin.Logging);
     configPlugin(): void;
     validate(): Promise<void>;
     instrumentFunction(originalDefinition: Serverless.FunctionDefinition, setEnv: boolean): FunctionDefinitionWithSentry;

--- a/dist/index.js
+++ b/dist/index.js
@@ -61,10 +61,11 @@ var _e = encodeURIComponent;
  * Serverless Plugin forward Lambda exceptions to Sentry (https://sentry.io)
  */
 var SentryPlugin = /** @class */ (function () {
-    function SentryPlugin(serverless, options) {
+    function SentryPlugin(serverless, options, logging) {
         var _this = this;
         this.serverless = serverless;
         this.options = options;
+        this.logging = logging;
         this.custom = this.serverless.service.custom;
         this.provider = this.serverless.getProvider("aws");
         // Create schema for our properties. For reference use https://github.com/ajv-validator/ajv
@@ -179,11 +180,13 @@ var SentryPlugin = /** @class */ (function () {
                         case 0: return [4 /*yield*/, this.createSentryRelease()];
                         case 1:
                             _a.sent();
-                            return [4 /*yield*/, this.uploadSentrySourcemaps()];
-                        case 2:
-                            _a.sent();
+                            // uploading sentry source maps doesn't work for "deploy function" command #67
+                            // TODO to add proper fix once it's addressed on serverless-core https://github.com/serverless/serverless/issues/11179
+                            this.logging.log.warning('Uploading source maps is skipped for "deploy function" because it is not working');
+                            // await this.uploadSentrySourcemaps();
                             return [4 /*yield*/, this.deploySentryRelease()];
-                        case 3:
+                        case 2:
+                            // await this.uploadSentrySourcemaps();
                             _a.sent();
                             return [2 /*return*/];
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,15 +80,17 @@ export class SentryPlugin implements Plugin {
   sentry: Partial<SentryOptions>;
   serverless: Serverless;
   options: Serverless.Options;
+  logging: Plugin.Logging;
   custom: Service.Custom;
   hooks: { [event: string]: (...rest: any[]) => any };
   provider: Aws;
   validated: boolean;
   isInstrumented: boolean;
 
-  constructor(serverless: Serverless, options: Serverless.Options) {
+  constructor(serverless: Serverless, options: Serverless.Options, logging: Plugin.Logging) {
     this.serverless = serverless;
     this.options = options;
+    this.logging = logging;
     this.custom = this.serverless.service.custom;
     this.provider = this.serverless.getProvider("aws");
 
@@ -162,7 +164,10 @@ export class SentryPlugin implements Plugin {
 
       "after:deploy:function:deploy": async () => {
         await this.createSentryRelease();
-        await this.uploadSentrySourcemaps();
+        // uploading sentry source maps doesn't work for "deploy function" command #67
+        // TODO to add proper fix once it's addressed on serverless-core https://github.com/serverless/serverless/issues/11179
+        this.logging.log.warning('Uploading source maps is skipped for "deploy function" because it is not working');
+        // await this.uploadSentrySourcemaps();
         await this.deploySentryRelease();
       },
 


### PR DESCRIPTION
Because https://github.com/serverless/serverless/issues/11179 is taking longer to address it's safer to disable this functionality to avoid UX degradation. It's very annoying to see `sls deploy function` failure, much better to have function code actually deployed, but with warning.